### PR TITLE
Error handling

### DIFF
--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -23,4 +23,5 @@ module ApiBlueprint
   class BuilderError < StandardError; end
   class ServerError < StandardError; end
   class UnauthenticatedError < StandardError; end
+  class ClientError < StandardError; end
 end

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -7,6 +7,7 @@ require 'active_model'
 require 'active_support/core_ext/hash'
 require 'addressable'
 
+require 'api-blueprint/response_middleware'
 require 'api-blueprint/cache'
 require 'api-blueprint/types'
 require 'api-blueprint/url'
@@ -20,4 +21,6 @@ require 'api-blueprint/collection'
 module ApiBlueprint
   class DefinitionError < StandardError; end
   class BuilderError < StandardError; end
+  class ServerError < StandardError; end
+  class UnauthenticatedError < StandardError; end
 end

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -32,7 +32,7 @@ module ApiBlueprint
       response = call_api all_request_options(options)
 
       if creates.present?
-        created = build from: response.body, headers: response.headers
+        created = build from: response.body, headers: response.headers, status: response.status
       else
         created = response
       end
@@ -42,10 +42,11 @@ module ApiBlueprint
 
     private
 
-    def build(from:, headers: {})
+    def build(from:, headers: {}, status: nil)
       builder_options = {
         body: parser.parse(from),
         headers: headers,
+        status: status,
         replacements: replacements,
         creates: creates
       }

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -68,7 +68,6 @@ module ApiBlueprint
       Faraday.new do |conn|
         conn.use ApiBlueprint::ResponseMiddleware
         conn.response :json, content_type: /\bjson$/
-        # conn.response :raise_error
         # conn.response :logger
 
         conn.adapter Faraday.default_adapter

--- a/lib/api-blueprint/builder.rb
+++ b/lib/api-blueprint/builder.rb
@@ -4,6 +4,7 @@ module ApiBlueprint
 
     attribute :body, Types::Hash.default(Hash.new)
     attribute :headers, Types::Hash.default(Hash.new)
+    attribute :status, Types::Int.optional
     attribute :replacements, Types::Hash.default(Hash.new)
     attribute :creates, Types::Any
 
@@ -18,7 +19,12 @@ module ApiBlueprint
     end
 
     def prepare_item(item)
-      with_replacements item.with_indifferent_access
+      meta = {
+        response_headers: headers,
+        response_status: status
+      }
+
+      meta.merge with_replacements(item.deep_symbolize_keys)
     end
 
     def build_item(item)

--- a/lib/api-blueprint/model.rb
+++ b/lib/api-blueprint/model.rb
@@ -14,6 +14,9 @@ module ApiBlueprint
     setting :builder, Builder.new
     setting :replacements, {}
 
+    attribute :response_headers, Types::Hash.optional
+    attribute :response_status, Types::Int.optional
+
     def self.blueprint(http_method, url, options = {}, &block)
       blueprint_opts = {
         http_method: http_method,
@@ -33,6 +36,10 @@ module ApiBlueprint
 
     def self.collection(blueprints)
       Collection.new blueprints, self
+    end
+
+    def api_request_success?
+      response_status.present? && (200...299).include?(response_status)
     end
 
   end

--- a/lib/api-blueprint/parser.rb
+++ b/lib/api-blueprint/parser.rb
@@ -5,6 +5,8 @@ module ApiBlueprint
     # to make a custom parser.
     def parse(body)
       body.is_a?(String) ? JSON.parse(body) : body
+    rescue JSON::ParserError
+      {}
     end
 
   end

--- a/lib/api-blueprint/response_middleware.rb
+++ b/lib/api-blueprint/response_middleware.rb
@@ -5,7 +5,9 @@ module ApiBlueprint
       case env[:status]
       when 401
         raise ApiBlueprint::UnauthenticatedError, response_values(env)
-      when 499...599
+      when 402..499
+        raise ApiBlueprint::ClientError, response_values(env)
+      when 500...599
         raise ApiBlueprint::ServerError, response_values(env)
       end
     end

--- a/lib/api-blueprint/response_middleware.rb
+++ b/lib/api-blueprint/response_middleware.rb
@@ -1,0 +1,18 @@
+module ApiBlueprint
+  class ResponseMiddleware < Faraday::Response::Middleware
+
+    def on_complete(env)
+      case env[:status]
+      when 401
+        raise ApiBlueprint::UnauthenticatedError, response_values(env)
+      when 499...599
+        raise ApiBlueprint::ServerError, response_values(env)
+      end
+    end
+
+    def response_values(env)
+      { status: env.status, headers: env.response_headers, body: env.body }
+    end
+
+  end
+end

--- a/spec/api-blueprint/blueprint_spec.rb
+++ b/spec/api-blueprint/blueprint_spec.rb
@@ -204,12 +204,12 @@ describe ApiBlueprint::Blueprint, "building" do
   }
 
   it "passes the correct arguments to the builder" do
-    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: {}, creates: Car, headers: @headers).and_return(builder)
+    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: {}, creates: Car, headers: @headers, status: 200).and_return(builder)
     blueprint.run
   end
 
   it "passes replacements to the builder" do
-    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: { foo: :bar }, creates: Car, headers: @headers).and_return(builder)
+    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: { foo: :bar }, creates: Car, headers: @headers, status: 200).and_return(builder)
     blueprint_with_replacements.run
   end
 
@@ -245,7 +245,7 @@ describe ApiBlueprint::Blueprint, "building collections" do
   }
 
   it "passes the correct arguments to the builder" do
-    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: {}, creates: Car, headers: @headers).and_return(builder)
+    expect(ApiBlueprint::Builder).to receive(:new).with(body: @options, replacements: {}, creates: Car, headers: @headers, status: 200).and_return(builder)
     blueprint.run
   end
 

--- a/spec/api-blueprint/blueprint_spec.rb
+++ b/spec/api-blueprint/blueprint_spec.rb
@@ -360,15 +360,6 @@ describe ApiBlueprint::Blueprint, "running" do
     after_build = -> (_, response) { duck.quack }
     ApiBlueprint::Blueprint.new(url: "http://web/foo", after_build: after_build).run
   end
-
-  [404, 401, 500, 503].each do |status|
-    it "raises an exception when the response status is #{status}" do
-      stub_request(:get, "http://web/foo").to_return(status: status)
-      expect {
-        ApiBlueprint::Blueprint.new(url: "http://web/foo").run
-      }.to raise_error(Faraday::ClientError)
-    end
-  end
 end
 
 describe ApiBlueprint::Blueprint, "validation" do

--- a/spec/api-blueprint/builder_spec.rb
+++ b/spec/api-blueprint/builder_spec.rb
@@ -35,6 +35,17 @@ describe ApiBlueprint::Builder, "building collections" do
   end
 end
 
+describe ApiBlueprint::Builder, "response metadata" do
+  let(:body) { { name: "Ford", color: "red" } }
+  let(:headers) { { status: 200, "Content-Type": "application/json" }}
+  let(:builder) { ApiBlueprint::Builder.new(body: body, headers: headers, creates: Car) }
+  let(:car) { builder.build }
+
+  it "stores response headers on the created class" do
+    expect(car.response_headers).to eq headers
+  end
+end
+
 describe ApiBlueprint::Builder, "replacements" do
   let(:replacements) { { carName: :name, colour: :color } }
   let(:body) { { carName: "VW Camper", colour: "Blue" } }

--- a/spec/api-blueprint/full_run_spec.rb
+++ b/spec/api-blueprint/full_run_spec.rb
@@ -51,4 +51,45 @@ describe "End-to-end test" do
       expect(result.second_largest.name).to eq "Manchester City"
     end
   end
+
+  describe "Handling different responses from the API" do
+    context "400 bad request" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return \
+          body: { name: "London City", errors: { name: ["some error", "another error"] } }.to_json,
+          status: 400
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "doesn't raise an exception" do
+        expect {
+          result
+        }.not_to raise_error
+      end
+
+      it "sets errors on the instance" do
+        expect(result.errors[:name]).to include "some error"
+        expect(result.errors[:name]).to include "another error"
+      end
+
+      it "sets the normal attributes" do
+        expect(result.name).to eq "London City"
+      end
+    end
+
+    context "401 unauthenticated" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return status: 401
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "raises an UnauthenticatedError" do
+        expect {
+          result
+        }.to raise_error(ApiBlueprint::UnauthenticatedError)
+      end
+    end
+  end
 end

--- a/spec/api-blueprint/full_run_spec.rb
+++ b/spec/api-blueprint/full_run_spec.rb
@@ -91,5 +91,47 @@ describe "End-to-end test" do
         }.to raise_error(ApiBlueprint::UnauthenticatedError)
       end
     end
+
+    context "403 forbidden" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return status: 403
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "raises an ClientError" do
+        expect {
+          result
+        }.to raise_error(ApiBlueprint::ClientError)
+      end
+    end
+
+    context "500 internal server error" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return status: 500
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "raises an ServerError" do
+        expect {
+          result
+        }.to raise_error(ApiBlueprint::ServerError)
+      end
+    end
+
+    context "503 service unavailable" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return status: 503
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "raises an ServerError" do
+        expect {
+          result
+        }.to raise_error(ApiBlueprint::ServerError)
+      end
+    end
   end
 end

--- a/spec/api-blueprint/model_spec.rb
+++ b/spec/api-blueprint/model_spec.rb
@@ -46,6 +46,32 @@ describe ApiBlueprint::Model do
     ConfiguredModel.collection foo: blueprint
   end
 
+  describe "attributes" do
+    describe "response_headers" do
+      it "defaults to nil" do
+        model = PlainModel.new
+        expect(model.response_headers).to eq nil
+      end
+
+      it "sets the headers attribute" do
+        model = PlainModel.new response_headers: { foo: "Bar" }
+        expect(model.response_headers[:foo]).to eq "Bar"
+      end
+    end
+
+    describe "response_status" do
+      it "defaults to nil" do
+        model = PlainModel.new
+        expect(model.response_status).to eq nil
+      end
+
+      it "sets the status attribute" do
+        model = PlainModel.new response_status: 500
+        expect(model.response_status).to eq 500
+      end
+    end
+  end
+
   describe "config" do
     it "should set the default host to be a blank string" do
       expect(PlainModel.config.host).to eq ""
@@ -155,6 +181,25 @@ describe ApiBlueprint::Model do
     it "overrides config from the superclass" do
       expect(ChildModel.config.host).not_to eq ConfiguredModel.config.host
       expect(ChildModel.config.host).to eq "http://some-other-host.com"
+    end
+  end
+
+  describe "#api_request_success?" do
+    it "returns true if the response status is 200...299" do
+      (200...299).to_a.each do |i|
+        model = PlainModel.new response_status: i
+        expect(model.api_request_success?).to be true
+      end
+    end
+
+    it "returns false if the response status is not in the 200 range" do
+      model = PlainModel.new response_status: 404
+      expect(model.api_request_success?).to be false
+    end
+
+    it "returns false if response_status is nil" do
+      model = PlainModel.new
+      expect(model.api_request_success?).to be false
     end
   end
 end

--- a/spec/api-blueprint/runner_spec.rb
+++ b/spec/api-blueprint/runner_spec.rb
@@ -100,12 +100,12 @@ describe ApiBlueprint::Runner do
       end
 
       it "tries to write the created model to the cache" do
-        expect(cache).to receive(:write).with(cache_id, CacheTestModel.new(name: "FooBar"), {})
+        expect(cache).to receive(:write).with(cache_id, CacheTestModel.new(name: "FooBar", response_headers: {}, response_status: 200), {})
         runner.run blueprint
       end
 
       it "passes cache options to the cache#write call" do
-        expect(cache).to receive(:write).with(cache_id, CacheTestModel.new(name: "FooBar"), { foo: "bar" })
+        expect(cache).to receive(:write).with(cache_id, CacheTestModel.new(name: "FooBar", response_headers: {}, response_status: 200), { foo: "bar" })
         runner.run blueprint, foo: "bar"
       end
     end


### PR DESCRIPTION
Adding some basic error handling to responses, so ApiBlueprint will raise an exception when unexpected errors such as 404's, 401's, 500's, and will also store errors as ActiveModel::Errors. It also adds some convenience methods to set response headers and status codes on models which are built by the default builder to make it possible to see some metadata about the response.

🍩 