### PR TITLE
Include model name in cache keys

### DIFF
--- a/lib/api-blueprint/cache.rb
+++ b/lib/api-blueprint/cache.rb
@@ -16,10 +16,10 @@ module ApiBlueprint
       data
     end
 
-    def generate_cache_key(options)
+    def generate_cache_key(klass, options)
       options = options.clone.except :body
       options_digest = Digest::MD5.hexdigest Marshal::dump(options.to_s.chars.sort.join)
-      "#{key}:#{options_digest}"
+      "#{key}:#{klass&.name}:#{options_digest}"
     end
 
   end

--- a/lib/api-blueprint/runner.rb
+++ b/lib/api-blueprint/runner.rb
@@ -25,13 +25,13 @@ module ApiBlueprint
       request_options = blueprint.all_request_options(runner_options)
 
       if cache.present?
-        cache_key = cache.generate_cache_key request_options
+        cache_key = cache.generate_cache_key blueprint.creates, request_options
         return cache.read cache_key if cache.exist? cache_key
       end
 
       blueprint.run(runner_options, self).tap do |result|
         if cache.present?
-          cache_key = cache.generate_cache_key request_options
+          cache_key = cache.generate_cache_key blueprint.creates, request_options
           cache.write cache_key, result, cache_options
         end
       end

--- a/spec/api-blueprint/cache_spec.rb
+++ b/spec/api-blueprint/cache_spec.rb
@@ -10,32 +10,32 @@ describe ApiBlueprint::Cache do
   end
 
   describe "#generate_cache_key" do
-    it "should include the main cache key at the front and a string after" do
-      a = cache.generate_cache_key({ foo: "bar" })
-      expect(a).to match(/^test:(\w{10,})/)
+    it "should include the main cache key at the front, followed by the class, and a string after" do
+      a = cache.generate_cache_key(Car, { foo: "bar" })
+      expect(a).to match(/^test:Car:(\w{10,})/)
     end
 
     it "should return the same id from two hashes with the same data" do
-      a = cache.generate_cache_key({ foo: "bar" })
-      b = cache.generate_cache_key({ foo: "bar" })
+      a = cache.generate_cache_key(Car, { foo: "bar" })
+      b = cache.generate_cache_key(Car, { foo: "bar" })
       expect(a).to eq b
     end
 
     it "should not matter which order the keys are in" do
-      a = cache.generate_cache_key({ foo: "bar", baz: "box" })
-      b = cache.generate_cache_key({ baz: "box", foo: "bar" })
+      a = cache.generate_cache_key(Car, { foo: "bar", baz: "box" })
+      b = cache.generate_cache_key(Car, { baz: "box", foo: "bar" })
       expect(a).to eq b
     end
 
     it "should return a new id if the hashes are different" do
-      a = cache.generate_cache_key({ foo: "bar" })
-      b = cache.generate_cache_key({ baz: "box" })
+      a = cache.generate_cache_key(Car, { foo: "bar" })
+      b = cache.generate_cache_key(Car, { baz: "box" })
       expect(a).not_to eq b
     end
 
     it "should not use the body key from the options hash" do
-      a = cache.generate_cache_key({ foo: "bar" })
-      b = cache.generate_cache_key({ foo: "bar", body: "foo" })
+      a = cache.generate_cache_key(Car, { foo: "bar" })
+      b = cache.generate_cache_key(Car, { foo: "bar", body: "foo" })
       expect(a).to eq b
     end
   end

--- a/spec/api-blueprint/runner_spec.rb
+++ b/spec/api-blueprint/runner_spec.rb
@@ -69,7 +69,7 @@ describe ApiBlueprint::Runner do
     let(:cache) { ApiBlueprint::Cache.new key: "test" }
     let(:runner) { ApiBlueprint::Runner.new cache: cache }
     let(:blueprint) { ApiBlueprint::Blueprint.new url: "http://cache", creates: CacheTestModel }
-    let(:cache_id) { cache.generate_cache_key blueprint.all_request_options(runner.runner_options) }
+    let(:cache_id) { cache.generate_cache_key CacheTestModel, blueprint.all_request_options(runner.runner_options) }
 
     before do
       @stub = stub_request(:get, "http://cache").to_return({


### PR DESCRIPTION
Previously, cache keys were just "key:checksum" which made it hard to know what to expire when doing manual cache expiration. This changes it to "key:classname:checksum" so you can do things like this in the ApiBlueprint::Cache implementation to wipe a namespace: `Rails.cache.delete_matched "#{key}:#{klass.name}:*"`