### PR TITLE
Raise NotFoundError when response status is 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ Certain response statuses will also cause ApiBlueprint to behave in different wa
 
 | HTTP Status range | Behavior |
 | ----------------- | -------- |
-| 200 - 400 | Objects are built normally, no errors raised |
+| 200 - 399 | Objects are built normally, no errors raised |
 | 401 | raises `ApiBlueprint::UnauthenticatedError` |
-| 402 - 499 | raises `ApiBlueprint::ClientError` |
+| 404 | raises `ApiBlueprint::NotFoundError` |
+| 400 - 499 | raises `ApiBlueprint::ClientError` |
 | 500 - 599 | raises `ApiBlueprint::ServerError` |
 
 ## Access to response headers and status codes

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -24,4 +24,5 @@ module ApiBlueprint
   class ServerError < StandardError; end
   class UnauthenticatedError < StandardError; end
   class ClientError < StandardError; end
+  class NotFoundError < StandardError; end
 end

--- a/lib/api-blueprint/response_middleware.rb
+++ b/lib/api-blueprint/response_middleware.rb
@@ -5,6 +5,8 @@ module ApiBlueprint
       case env[:status]
       when 401
         raise ApiBlueprint::UnauthenticatedError, response_values(env)
+      when 404
+        raise ApiBlueprint::NotFoundError, response_values(env)
       when 402..499
         raise ApiBlueprint::ClientError, response_values(env)
       when 500...599

--- a/spec/api-blueprint/full_run_spec.rb
+++ b/spec/api-blueprint/full_run_spec.rb
@@ -120,6 +120,20 @@ describe "End-to-end test" do
       end
     end
 
+    context "404 not found" do
+      before do
+        stub_request(:get, "http://cities/?name=London").to_return status: 404
+      end
+
+      let(:result) { runner.run City.fetch("London") }
+
+      it "raises an ClientError" do
+        expect {
+          result
+        }.to raise_error(ApiBlueprint::NotFoundError)
+      end
+    end
+
     context "500 internal server error" do
       before do
         stub_request(:get, "http://cities/?name=London").to_return status: 500


### PR DESCRIPTION
Raise `ApiBlueprint::NotFoundError` instead of a generic `ApiBlueprint::ClientError` when response status is 404.