### PR TITLE
Adding request error data to exceptions in a more accessible way

### DIFF
--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -19,10 +19,19 @@ require 'api-blueprint/runner'
 require 'api-blueprint/collection'
 
 module ApiBlueprint
+  class ResponseError < StandardError
+    attr_reader :status, :headers, :body
+    def initialize(env)
+      @status = env.status
+      @headers = env.response_headers.symbolize_keys
+      @body = env.body
+    end
+  end
+
   class DefinitionError < StandardError; end
   class BuilderError < StandardError; end
-  class ServerError < StandardError; end
-  class UnauthenticatedError < StandardError; end
-  class ClientError < StandardError; end
-  class NotFoundError < StandardError; end
+  class ServerError < ResponseError; end
+  class UnauthenticatedError < ResponseError; end
+  class ClientError < ResponseError; end
+  class NotFoundError < ResponseError; end
 end

--- a/lib/api-blueprint/response_middleware.rb
+++ b/lib/api-blueprint/response_middleware.rb
@@ -4,18 +4,14 @@ module ApiBlueprint
     def on_complete(env)
       case env[:status]
       when 401
-        raise ApiBlueprint::UnauthenticatedError, response_values(env)
+        raise ApiBlueprint::UnauthenticatedError.new(env)
       when 404
-        raise ApiBlueprint::NotFoundError, response_values(env)
+        raise ApiBlueprint::NotFoundError.new(env)
       when 402..499
-        raise ApiBlueprint::ClientError, response_values(env)
+        raise ApiBlueprint::ClientError.new(env)
       when 500...599
-        raise ApiBlueprint::ServerError, response_values(env)
+        raise ApiBlueprint::ServerError.new(env)
       end
-    end
-
-    def response_values(env)
-      { status: env.status, headers: env.response_headers, body: env.body }
     end
 
   end

--- a/spec/api-blueprint/full_run_spec.rb
+++ b/spec/api-blueprint/full_run_spec.rb
@@ -67,14 +67,21 @@ describe "End-to-end test" do
   end
 
   describe "Handling different statuses from the API" do
+    let(:result) { runner.run City.fetch("London") }
+    let(:error) do
+      begin
+        result
+      rescue Exception => e
+        e
+      end
+    end
+
     context "400 bad request" do
       before do
         stub_request(:get, "http://cities/?name=London").to_return \
           body: { name: "London City", errors: { name: ["some error", "another error"] } }.to_json,
           status: 400
       end
-
-      let(:result) { runner.run City.fetch("London") }
 
       it "doesn't raise an exception" do
         expect {
@@ -94,21 +101,31 @@ describe "End-to-end test" do
 
     context "401 unauthenticated" do
       before do
-        stub_request(:get, "http://cities/?name=London").to_return status: 401
+        stub_request(:get, "http://cities/?name=London").to_return status: 401, headers: { hello: "world" }, body: "hi"
       end
-
-      let(:result) { runner.run City.fetch("London") }
 
       it "raises an UnauthenticatedError" do
         expect {
           result
         }.to raise_error(ApiBlueprint::UnauthenticatedError)
       end
+
+      it "includes the status in the error" do
+        expect(error.status).to eq 401
+      end
+
+      it "includes the headers in the error" do
+        expect(error.headers).to eq({ hello: "world" })
+      end
+
+      it "includes the body in the error" do
+        expect(error.body).to eq "hi"
+      end
     end
 
     context "403 forbidden" do
       before do
-        stub_request(:get, "http://cities/?name=London").to_return status: 403
+        stub_request(:get, "http://cities/?name=London").to_return status: 403, headers: { hello: "world" }, body: "hi"
       end
 
       let(:result) { runner.run City.fetch("London") }
@@ -118,11 +135,23 @@ describe "End-to-end test" do
           result
         }.to raise_error(ApiBlueprint::ClientError)
       end
+
+      it "includes the status in the error" do
+        expect(error.status).to eq 403
+      end
+
+      it "includes the headers in the error" do
+        expect(error.headers).to eq({ hello: "world" })
+      end
+
+      it "includes the body in the error" do
+        expect(error.body).to eq "hi"
+      end
     end
 
     context "404 not found" do
       before do
-        stub_request(:get, "http://cities/?name=London").to_return status: 404
+        stub_request(:get, "http://cities/?name=London").to_return status: 404, headers: { error: "not found" }, body: "Not Found :("
       end
 
       let(:result) { runner.run City.fetch("London") }
@@ -132,11 +161,23 @@ describe "End-to-end test" do
           result
         }.to raise_error(ApiBlueprint::NotFoundError)
       end
+
+      it "includes the status in the error" do
+        expect(error.status).to eq 404
+      end
+
+      it "includes the headers in the error" do
+        expect(error.headers).to eq({ error: "not found" })
+      end
+
+      it "includes the body in the error" do
+        expect(error.body).to eq "Not Found :("
+      end
     end
 
     context "500 internal server error" do
       before do
-        stub_request(:get, "http://cities/?name=London").to_return status: 500
+        stub_request(:get, "http://cities/?name=London").to_return status: 500, headers: { server: "dead" }, body: ":("
       end
 
       let(:result) { runner.run City.fetch("London") }
@@ -145,12 +186,24 @@ describe "End-to-end test" do
         expect {
           result
         }.to raise_error(ApiBlueprint::ServerError)
+      end
+
+      it "includes the status in the error" do
+        expect(error.status).to eq 500
+      end
+
+      it "includes the headers in the error" do
+        expect(error.headers).to eq({ server: "dead" })
+      end
+
+      it "includes the body in the error" do
+        expect(error.body).to eq ":("
       end
     end
 
     context "503 service unavailable" do
       before do
-        stub_request(:get, "http://cities/?name=London").to_return status: 503
+        stub_request(:get, "http://cities/?name=London").to_return status: 503, headers: { unavailable: "yep" }, body: ":S"
       end
 
       let(:result) { runner.run City.fetch("London") }
@@ -159,6 +212,18 @@ describe "End-to-end test" do
         expect {
           result
         }.to raise_error(ApiBlueprint::ServerError)
+      end
+
+      it "includes the status in the error" do
+        expect(error.status).to eq 503
+      end
+
+      it "includes the headers in the error" do
+        expect(error.headers).to eq({ unavailable: "yep" })
+      end
+
+      it "includes the body in the error" do
+        expect(error.body).to eq ":S"
       end
     end
   end


### PR DESCRIPTION
`raise ApiBlueprint::UnauthenticatedError, response_values(env)` meant that the `response_values` were a string, which was pretty useless. This means that the error object is an instance with `.status`, `.body` and `.headers`.