### PR TITLE
Updating to use the most recent versions of Dry::Types and Dry::Struct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api-blueprint (0.5.0)
+    api-blueprint (0.6.0)
       activemodel
       activesupport
       addressable
@@ -37,24 +37,24 @@ GEM
     dry-core (0.4.5)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.1)
+    dry-inflector (0.1.2)
     dry-initializer (2.4.0)
     dry-logic (0.4.2)
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-struct (0.4.0)
-      dry-core (~> 0.4, >= 0.4.1)
+    dry-struct (0.5.0)
+      dry-core (~> 0.4, >= 0.4.3)
       dry-equalizer (~> 0.2)
-      dry-types (~> 0.12, >= 0.12.2)
+      dry-types (~> 0.13)
       ice_nine (~> 0.11)
-    dry-types (0.12.2)
+    dry-types (0.13.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1)
       dry-container (~> 0.3)
-      dry-core (~> 0.2, >= 0.2.1)
+      dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer (~> 0.2)
+      dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 0.4, >= 0.4.2)
-      inflecto (~> 0.0.0, >= 0.0.2)
     faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -79,7 +79,6 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inflecto (0.0.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -7,6 +7,7 @@ require 'active_model'
 require 'active_support/core_ext/hash'
 require 'addressable'
 
+require 'api-blueprint/struct'
 require 'api-blueprint/response_middleware'
 require 'api-blueprint/cache'
 require 'api-blueprint/types'

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -1,14 +1,12 @@
 module ApiBlueprint
-  class Blueprint < Dry::Struct
-    constructor_type :schema
-
+  class Blueprint < ApiBlueprint::Struct
     attribute :http_method, Types::Symbol.default(:get).enum(*Faraday::Connection::METHODS)
     attribute :url, Types::String
     attribute :headers, Types::Hash.default(Hash.new)
     attribute :params, Types::Hash.default(Hash.new)
     attribute :body, Types::Hash.default(Hash.new)
     attribute :creates, Types::Any
-    attribute :parser, Types.Instance(ApiBlueprint::Parser).default(ApiBlueprint::Parser.new)
+    attribute :parser, Types.Instance(ApiBlueprint::Parser).optional.default(ApiBlueprint::Parser.new)
     attribute :replacements, Types::Hash.default(Hash.new)
     attribute :after_build, Types::Instance(Proc).optional
     attribute :builder, Types.Instance(ApiBlueprint::Builder).default(ApiBlueprint::Builder.new)

--- a/lib/api-blueprint/builder.rb
+++ b/lib/api-blueprint/builder.rb
@@ -1,12 +1,11 @@
 module ApiBlueprint
-  class Builder < Dry::Struct
-    constructor_type :schema
+  class Builder < ApiBlueprint::Struct
 
     attribute :body, Types::Hash.default(Hash.new)
     attribute :headers, Types::Hash.default(Hash.new)
-    attribute :status, Types::Int.optional
+    attribute :status, Types::Integer.optional
     attribute :replacements, Types::Hash.default(Hash.new)
-    attribute :creates, Types::Any
+    attribute :creates, Types::Any.optional
 
     attr_writer :body
 

--- a/lib/api-blueprint/model.rb
+++ b/lib/api-blueprint/model.rb
@@ -1,5 +1,5 @@
 module ApiBlueprint
-  class Model < Dry::Struct
+  class Model < ApiBlueprint::Struct
     extend Dry::Configurable
     include ActiveModel::Conversion
     include ActiveModel::Validations
@@ -7,15 +7,13 @@ module ApiBlueprint
     extend ActiveModel::Naming
     extend ActiveModel::Callbacks
 
-    constructor_type :schema
-
     setting :host, ""
     setting :parser, Parser.new
     setting :builder, Builder.new
     setting :replacements, {}
 
     attribute :response_headers, Types::Hash.optional
-    attribute :response_status, Types::Int.optional
+    attribute :response_status, Types::Integer.optional
 
     def self.blueprint(http_method, url, options = {}, &block)
       blueprint_opts = {

--- a/lib/api-blueprint/struct.rb
+++ b/lib/api-blueprint/struct.rb
@@ -1,0 +1,9 @@
+module ApiBlueprint
+  class Struct < Dry::Struct
+    transform_keys &:to_sym
+
+    transform_types do |type|
+      type.default? ? type : type.meta(omittable: true)
+    end
+  end
+end

--- a/lib/api-blueprint/version.rb
+++ b/lib/api-blueprint/version.rb
@@ -1,3 +1,3 @@
 module ApiBlueprint
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
… Which removed constructor_type :schema, so we need to use transforms to be more lax with attributes.