### PR TITLE
Exclude response metadata from serialization

### DIFF
--- a/lib/api-blueprint/model.rb
+++ b/lib/api-blueprint/model.rb
@@ -4,6 +4,7 @@ module ApiBlueprint
     include ActiveModel::Conversion
     include ActiveModel::Validations
     include ActiveModel::Serialization
+    include ActiveModel::Serializers::JSON
     extend ActiveModel::Naming
     extend ActiveModel::Callbacks
 
@@ -38,6 +39,10 @@ module ApiBlueprint
 
     def api_request_success?
       response_status.present? && (200...299).include?(response_status)
+    end
+
+    def as_json
+      super.except :response_headers, :response_status
     end
 
   end

--- a/spec/api-blueprint/model_spec.rb
+++ b/spec/api-blueprint/model_spec.rb
@@ -202,4 +202,28 @@ describe ApiBlueprint::Model do
       expect(model.api_request_success?).to be false
     end
   end
+
+  describe "#as_json" do
+    let(:json) do
+      model = ChildModel.new \
+        foo: "foo",
+        bar: "bar",
+        response_headers: { "Content-Type": "application/json" },
+        response_status: 200
+      model.as_json
+    end
+
+    it "should include attributes" do
+      expect(json[:foo]).to eq "foo"
+      expect(json[:bar]).to eq "bar"
+    end
+
+    it "should not include response_headers" do
+      expect(json).not_to have_key(:response_headers)
+    end
+
+    it "should not include response_status" do
+      expect(json).not_to have_key(:response_status)
+    end
+  end
 end


### PR DESCRIPTION
The metadata is only useful in controllers when you're handling the responses, and shouldn't be included when serializing the resulting models (you could always re-include them if you wanted to override this in a model)