### PR TITLE
Detailed Logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       dry-struct
       dry-types
       faraday
+      faraday-detailed_logger
       faraday_middleware
 
 GEM
@@ -57,6 +58,8 @@ GEM
       dry-logic (~> 0.4, >= 0.4.2)
     faraday (0.15.1)
       multipart-post (>= 1.2, < 3)
+    faraday-detailed_logger (2.1.2)
+      faraday (~> 0.8)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.23)

--- a/apiblueprint.gemspec
+++ b/apiblueprint.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "dry-configurable"
   s.add_dependency "faraday"
   s.add_dependency "faraday_middleware"
+  s.add_dependency "faraday-detailed_logger"
   s.add_dependency "activemodel"
   s.add_dependency "activesupport"
   s.add_dependency "addressable"

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -3,6 +3,7 @@ require 'dry-struct'
 require 'dry-initializer'
 require 'faraday'
 require 'faraday_middleware'
+require 'faraday/detailed_logger'
 require 'active_model'
 require 'addressable'
 require 'active_support'
@@ -21,6 +22,10 @@ require 'api-blueprint/runner'
 require 'api-blueprint/collection'
 
 module ApiBlueprint
+  extend Dry::Configurable
+
+  setting :logger, nil
+
   class ResponseError < StandardError
     attr_reader :status, :headers, :body
     def initialize(env)

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -46,7 +46,7 @@ module ApiBlueprint
         conn.use :instrumentation, name: "api-blueprint.request"
 
         if enable_response_logging?
-          conn.response :detailed_logger, ApiBlueprint.config.logger, "api-blueprint"
+          conn.response :detailed_logger, ApiBlueprint.config.logger, "API-BLUEPRINT"
         end
 
         conn.adapter Faraday.default_adapter

--- a/spec/api_blueprint_spec.rb
+++ b/spec/api_blueprint_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe ApiBlueprint, "config" do
   describe "logger" do
     it "should default to nil" do
-      expect(ApiBlueprint.config.logger)
+      expect(ApiBlueprint.config.logger).to be nil
     end
 
     it "should be possible to set it as a custom logger" do

--- a/spec/api_blueprint_spec.rb
+++ b/spec/api_blueprint_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe ApiBlueprint, "config" do
+  describe "logger" do
+    it "should default to nil" do
+      expect(ApiBlueprint.config.logger)
+    end
+
+    it "should be possible to set it as a custom logger" do
+      logger = Logger.new(STDOUT)
+      ApiBlueprint.configure do |config|
+        config.logger = logger
+      end
+
+      expect(ApiBlueprint.config.logger).to eq logger
+    end
+  end
+end


### PR DESCRIPTION
The detailed logging middleware is much better because it logs response bodies. It's a very dangerous thing to do in prod, though, so I've added a safeguard - in production, `log_responses` is ignored unless the `ENABLE_PRODUCTION_RESPONSE_LOGGING` env variable is set.

I've also set up the instrumentation middleware to make it possible to subscribe to request notifications through `ActiveSupport::Notifications`.

This also includes a `ApiBlueprint.config.logger` setting which makes it possible to configure the gem to use an instance of the Rails logger instead of stdout. 