### PR TITLE
Respect key replacements in model constructors

### DIFF
--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -9,6 +9,7 @@ require 'addressable'
 require 'active_support'
 require 'active_support/core_ext'
 
+require 'api-blueprint/key_replacer'
 require 'api-blueprint/struct'
 require 'api-blueprint/response_middleware'
 require 'api-blueprint/cache'

--- a/lib/api-blueprint/builder.rb
+++ b/lib/api-blueprint/builder.rb
@@ -23,7 +23,7 @@ module ApiBlueprint
         response_status: status
       }
 
-      meta.merge with_replacements(item.deep_symbolize_keys)
+      meta.merge KeyReplacer.replace(item.deep_symbolize_keys, replacements)
     end
 
     def build_item(item)
@@ -31,16 +31,6 @@ module ApiBlueprint
         creates.new item
       else
         raise BuilderError, "To build an object, you must set #creates"
-      end
-    end
-
-    private
-
-    def with_replacements(item)
-      item.tap do |item|
-        replacements.each do |bad, good|
-          item[good] = item.delete bad if item.has_key? bad
-        end
       end
     end
 

--- a/lib/api-blueprint/key_replacer.rb
+++ b/lib/api-blueprint/key_replacer.rb
@@ -1,0 +1,13 @@
+module ApiBlueprint
+  class KeyReplacer
+
+    def self.replace(attributes, replacements)
+      attributes.dup.tap do |item|
+        replacements.each do |bad, good|
+          item[good] = item.delete bad if item.has_key? bad
+        end
+      end
+    end
+
+  end
+end

--- a/lib/api-blueprint/key_replacer.rb
+++ b/lib/api-blueprint/key_replacer.rb
@@ -2,7 +2,7 @@ module ApiBlueprint
   class KeyReplacer
 
     def self.replace(attributes, replacements)
-      attributes.dup.tap do |item|
+      attributes.dup.deep_symbolize_keys.tap do |item|
         replacements.each do |bad, good|
           item[good] = item.delete bad if item.has_key? bad
         end

--- a/lib/api-blueprint/struct.rb
+++ b/lib/api-blueprint/struct.rb
@@ -5,5 +5,13 @@ module ApiBlueprint
     transform_types do |type|
       type.default? ? type : type.meta(omittable: true)
     end
+
+    def self.new(attributes = default_attributes)
+      if respond_to?(:config) && config.replacements
+        attributes = KeyReplacer.replace(attributes, config.replacements)
+      end
+
+      super
+    end
   end
 end

--- a/spec/api-blueprint/key_replacer_spec.rb
+++ b/spec/api-blueprint/key_replacer_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe ApiBlueprint::KeyReplacer, ".replace" do
+  let(:original) { { foo: "Foo", bar: "Bar" } }
+  let(:replacements) { { foo: :foo_bar } }
+  let(:replaced) { ApiBlueprint::KeyReplacer.replace(original, replacements) }
+
+  it "renames keys defined in the replacements hash" do
+    expect(replaced[:foo]).to be nil
+    expect(replaced[:foo_bar]).to eq "Foo"
+  end
+
+  it "doesn't rename keys not in replacements" do
+    expect(replaced[:bar]).to eq "Bar"
+  end
+end

--- a/spec/api-blueprint/model_spec.rb
+++ b/spec/api-blueprint/model_spec.rb
@@ -13,7 +13,7 @@ class ConfiguredModel < ApiBlueprint::Model
     config.host = "http://foobar.com"
     config.parser = nil
     config.builder = CustomBuilder.new
-    config.replacements = { foo: :bar }
+    config.replacements = { some_bad_key: :foo }
     config.log_responses = true
   end
 end
@@ -99,7 +99,7 @@ describe ApiBlueprint::Model do
     end
 
     it "is possible to set the replacements" do
-      expect(ConfiguredModel.config.replacements).to eq({ foo: :bar })
+      expect(ConfiguredModel.config.replacements).to eq({ some_bad_key: :foo })
     end
 
     it "should set the default log_responses to false" do
@@ -158,7 +158,7 @@ describe ApiBlueprint::Model do
 
     it "uses the models default replacements" do
       bp = ConfiguredModel.blueprint :post, "/foo"
-      expect(bp.replacements).to eq({ foo: :bar })
+      expect(bp.replacements).to eq({ some_bad_key: :foo })
     end
 
     it "passes a block to the blueprint as after_build" do

--- a/spec/api-blueprint/struct_spec.rb
+++ b/spec/api-blueprint/struct_spec.rb
@@ -1,6 +1,52 @@
 require "spec_helper"
 
-describe ApiBlueprint::Model, "replacements in constructors" do
+describe ApiBlueprint::Struct, "initializing with strings or symbols" do
+  context "with strings as keys" do
+    let(:result) do
+      body = {
+        "cars" => [
+          { "name" => "Tesla" },
+          { "name" => "Ford" }
+        ]
+      }
+
+      CarPark.new body
+    end
+
+    it "sets the correct attribute" do
+      expect(result.cars.length).to eq 2
+    end
+
+    it "sets nested classes correctly" do
+      expect(result.cars[0].name).to eq "Tesla"
+      expect(result.cars[1].name).to eq "Ford"
+    end
+  end
+
+  context "with symbols as keys" do
+    let(:result) do
+      body = {
+        cars: [
+          { name: "Tesla" },
+          { name: "Ford" }
+        ]
+      }
+
+      CarPark.new body
+    end
+
+    it "sets the correct attribute" do
+      expect(result.cars.length).to eq 2
+    end
+
+    it "sets nested classes correctly" do
+      expect(result.cars[0].name).to eq "Tesla"
+      expect(result.cars[1].name).to eq "Ford"
+    end
+  end
+end
+
+describe ApiBlueprint::Struct, "replacements in constructors" do
   it "replaces keys in constructors" do
     expect(Car.new(car_name: "Ford").name).to eq "Ford"
   end
@@ -10,5 +56,9 @@ describe ApiBlueprint::Model, "replacements in constructors" do
     expect(car.name).to be nil
     next_car = car.new car_name: "Mazda"
     expect(next_car.name).to eq "Mazda"
+  end
+
+  it "replaces keys which are strings in the attributes and symbols in the replacements" do
+    expect(Car.new("car_name" => "Dodge").name).to eq "Dodge"
   end
 end

--- a/spec/api-blueprint/struct_spec.rb
+++ b/spec/api-blueprint/struct_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe ApiBlueprint::Model, "replacements in constructors" do
+  it "replaces keys in constructors" do
+    expect(Car.new(car_name: "Ford").name).to eq "Ford"
+  end
+
+  it "replaces keys when creating a new instance from an instance" do
+    car = Car.new
+    expect(car.name).to be nil
+    next_car = car.new car_name: "Mazda"
+    expect(next_car.name).to eq "Mazda"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@ class Car < ApiBlueprint::Model
 
   configure do |config|
     config.host = "http://car"
+    config.replacements = {
+      car_name: :name
+    }
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ class Car < ApiBlueprint::Model
   end
 end
 
+class CarPark < ApiBlueprint::Model
+  attribute :cars, Types::Array.of(Types.Constructor(Car))
+end
+
 class CarWithValidation < Car
   validates :name, presence: true
 end


### PR DESCRIPTION
Previously, key replacement only occurred in builders, which is great when dealing with the api response directly, but if the class being constructed is being constructed via a relationship, then the replacement logic never happens, which kinda sucked.

Imagine models like these:

```ruby
class Astronaut < ApiBlueprint::Model
  attribute :name, Types::String

  configure do |config|
    config.replacements = {
      astronaut_name: :name
    }
  end

  def self.fetch
    blueprint :get, "/astronaut"
  end
end

class AstrosInSpace < ApiBlueprint::Model
  attribute :astros, Types::Array.of(Types.Constructor(Astronaut))

  def self.fetch_all
    blueprint :get, "/astronauts"
  end
end
```

With the old logic, running `Astronaut.fetch` would've renamed `astronaut_name` to `astronaut` in the api response, but running `AstrosInSpace.fetch_all` would've skipped it.