### PR TITLE
Cache key generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,20 @@ For example, to not include "X-Real-IP" and "X-Request-Id" headers, which would 
  end
 ```
 
+If you would like to override how the cache keys are generated, you can do it for all classes by redefining `generate_cache_key` in your cache class. If you only need to override the cache key for certain models (for example, a public api cache might not want to use the session id to make the cache keys unique), you can do so by implementing a `cache_key_generator` proc on your model config:
+
+```ruby
+class AstronautsInSpace < ApiBlueprint::Model
+  configure do |config|
+    config.cache_key_generator = -> (key, options) do
+      # `key` is the key which you have initialized the instance of the cache class with
+      # `options` is all the api-related options for the request (url, headers, body, etc)
+      "some-custom-cache-key-here"
+    end
+  end
+end
+```
+
 ## A note on Dry::Struct immutability
 
 Models you create use `Dry::Struct` to handle initialization and assignment. `Dry::Struct` is designed with immutability in mind, so if you need to mutate the objects you have, there are two possibilities; explicitly define an `attr_writer` for the attributes which you want to mutate, or do things the "Dry::Struct way" and use the current instance to initialize a new instance:

--- a/lib/api-blueprint/cache.rb
+++ b/lib/api-blueprint/cache.rb
@@ -20,13 +20,17 @@ module ApiBlueprint
     end
 
     def generate_cache_key(klass, options)
-      if options.is_a? Hash
-        options = options.clone.with_indifferent_access.except :body
-        options[:headers] = options[:headers].except *self.class.config.ignored_headers if options[:headers]
-      end
+      if klass&.cache_key_generator&.present?
+        klass.cache_key_generator.call key, options
+      else
+        if options.is_a? Hash
+          options = options.clone.with_indifferent_access.except :body
+          options[:headers] = options[:headers].except *self.class.config.ignored_headers if options[:headers]
+        end
 
-      options_digest = Digest::MD5.hexdigest Marshal::dump(options.to_s.chars.sort.join)
-      "#{key}:#{klass&.name}:#{options_digest}"
+        options_digest = Digest::MD5.hexdigest Marshal::dump(options.to_s.chars.sort.join)
+        "#{key}:#{klass&.name}:#{options_digest}"
+      end
     end
 
   end

--- a/lib/api-blueprint/model.rb
+++ b/lib/api-blueprint/model.rb
@@ -11,6 +11,7 @@ module ApiBlueprint
     setting :builder, Builder.new
     setting :replacements, {}
     setting :log_responses, false
+    setting :cache_key_generator, nil, reader: true
 
     attribute :response_headers, Types::Hash.optional
     attribute :response_status, Types::Integer.optional

--- a/spec/api-blueprint/cache_spec.rb
+++ b/spec/api-blueprint/cache_spec.rb
@@ -45,6 +45,19 @@ describe ApiBlueprint::Cache do
       expect(a).to eq b
     end
 
+    context "when a class defines its own cache_key_generator" do
+      it "should invoke the cache_key_generator" do
+        gen = double()
+        expect(gen).to receive(:call).with("test", { foo: "bar" })
+        expect(CarPark).to receive(:cache_key_generator).at_least(:once).and_return gen
+        cache.generate_cache_key(CarPark, { foo: "bar" })
+      end
+
+      it "should not generate its own cache key" do
+        expect(cache.generate_cache_key(CarPark, { foo: "bar" })).to eq "custom_cache_key"
+      end
+    end
+
     context "with ignored headers" do
       before do
         ApiBlueprint::Cache.configure do |config|

--- a/spec/api-blueprint/model_spec.rb
+++ b/spec/api-blueprint/model_spec.rb
@@ -23,6 +23,9 @@ class ChildModel < ConfiguredModel
 
   configure do |config|
     config.host = "http://some-other-host.com"
+    config.cache_key_generator = -> (key, options) do
+      "custom_cache_key"
+    end
   end
 end
 
@@ -108,6 +111,18 @@ describe ApiBlueprint::Model do
 
     it "is possible to set log_responses" do
       expect(ConfiguredModel.config.log_responses).to be true
+    end
+
+    it "should set the default cache_key_generator to nil" do
+      expect(PlainModel.config.cache_key_generator).to be_nil
+    end
+
+    it "is possible to set a cache_key_generator" do
+      expect(ChildModel.config.cache_key_generator).to be_a Proc
+    end
+
+    it "is possible to access the cache_key_generator through a class reader method" do
+      expect(ChildModel.cache_key_generator).to be_a Proc
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,12 @@ end
 
 class CarPark < ApiBlueprint::Model
   attribute :cars, Types::Array.of(Types.Constructor(Car))
+
+  configure do |config|
+    config.cache_key_generator = -> (key, options) do
+      "custom_cache_key"
+    end
+  end
 end
 
 class CarWithValidation < Car


### PR DESCRIPTION
Making it possible for models to define how their cache keys will be generated.