### PR TITLE
Timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Certain response statuses will also cause ApiBlueprint to behave in different wa
 | 402 - 499 | raises `ApiBlueprint::ClientError` |
 | 500 - 599 | raises `ApiBlueprint::ServerError` |
 
+Additionally, if the request timesout or some other error occurs which prevents the request from ever receiving a response, an `ApiBlueprint::ConnectionFailed` error will be raised.
+
 ## Access to response headers and status codes
 
 By default, ApiBlueprint tries to set `response_headers` and `response_status` on the model which is created from an API response. `ApiBlueprint::Model` also has a convenience method `api_request_success?` which can be used to easily assert whether a response was in the 200-399 range. This makes it simple to render different responses in controllers. For example:

--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ class AstronautsInSpace < ApiBlueprint::Model
 end
 ```
 
+## Timeouts
+
+The default request timeout is set to 5 seconds. You can change this on a per-blueprint basis by passing the `timeout` option to the blueprint:
+
+```ruby
+blueprint :get, "/endpoint", timeout: 10.seconds
+```
+
 ## A note on Dry::Struct immutability
 
 Models you create use `Dry::Struct` to handle initialization and assignment. `Dry::Struct` is designed with immutability in mind, so if you need to mutate the objects you have, there are two possibilities; explicitly define an `attr_writer` for the attributes which you want to mutate, or do things the "Dry::Struct way" and use the current instance to initialize a new instance:

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -38,6 +38,7 @@ module ApiBlueprint
 
   class DefinitionError < StandardError; end
   class BuilderError < StandardError; end
+  class ConnectionFailed < StandardError; end
   class ServerError < ResponseError; end
   class UnauthenticatedError < ResponseError; end
   class ClientError < ResponseError; end

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -11,6 +11,7 @@ module ApiBlueprint
     attribute :after_build, Types::Instance(Proc).optional
     attribute :builder, Types.Instance(ApiBlueprint::Builder).default(ApiBlueprint::Builder.new)
     attribute :log_responses, Types::Strict::Bool.default(false)
+    attribute :timeout, Types::Strict::Integer.default(5)
 
     def all_request_options(options = {})
       {
@@ -80,6 +81,7 @@ module ApiBlueprint
         req.headers.merge!({ "Content-Type": "application/json" }.merge(options[:headers]))
         req.params = options[:params]
         req.body = options[:body].to_json
+        req.options.timeout = timeout.to_i
       end
     end
 

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -37,6 +37,8 @@ module ApiBlueprint
       end
 
       after_build.present? ? after_build.call(runner, created) : created
+    rescue Faraday::ConnectionFailed
+      raise ApiBlueprint::ConnectionFailed, "timeout"
     end
 
     def connection

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -39,7 +39,7 @@ module ApiBlueprint
 
       after_build.present? ? after_build.call(runner, created) : created
     rescue Faraday::ConnectionFailed
-      raise ApiBlueprint::ConnectionFailed, "timeout"
+      raise ApiBlueprint::ConnectionFailed
     end
 
     def connection

--- a/spec/api-blueprint/blueprint_spec.rb
+++ b/spec/api-blueprint/blueprint_spec.rb
@@ -388,6 +388,16 @@ describe ApiBlueprint::Blueprint, "running" do
     after_build = -> (_, response) { duck.quack }
     ApiBlueprint::Blueprint.new(url: "http://web/foo", after_build: after_build).run
   end
+
+  context "when the request timesout" do
+    it "raises an ApiBlueprint::ConnectionFailed exception" do
+      stub_request(:get, "http://timeout").to_timeout
+
+      expect {
+        ApiBlueprint::Blueprint.new(url: "http://timeout").run
+      }.to raise_error(ApiBlueprint::ConnectionFailed)
+    end
+  end
 end
 
 describe ApiBlueprint::Blueprint, "validation" do

--- a/spec/api-blueprint/model_spec.rb
+++ b/spec/api-blueprint/model_spec.rb
@@ -182,6 +182,11 @@ describe ApiBlueprint::Model do
       end
       expect(bp.after_build.call).to eq "Hello"
     end
+
+    it "passes timeout to the blueprint" do
+      bp = ConfiguredModel.blueprint :post, "/foo", timeout: 150
+      expect(bp.timeout).to eq 150
+    end
   end
 
   it "passes the builder from the model config" do


### PR DESCRIPTION
Making it possible to change the default timeout on requests on a per-blueprint basis.

Also, re-throwing `Faraday::ConnectionFailed` as `ApiBlueprint::ConnectionFailed` so that all api exceptions can be caught in a consistent manner.