### PR TITLE
convert Faraday::TimeoutError to ApiBlueprint::TimeoutError

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 ### Config.builder
 
 When running a blueprint, after the response is returned and parsed, the result is passed to a builder, which is responsible for initializing objects from the response. The default [ApiBlueprint::Builder](https://github.com/iZettle/api-blueprint/blob/master/lib/api-blueprint/builder.rb)
- will pass the attributes from the response into the initializer for the class the blueprint was defined in.
+will pass the attributes from the response into the initializer for the class the blueprint was defined in.
 
 If you want to change the behavior of the builder, or have a complex response which needs manipulation before it should be passed to the initializer, you can define a custom builder. Custom builders must inherit from the default builder, and can override any combination of the core methods which are used to build responses; `build`, `prepare_item`, and `build_item`. Refer to the [default builder](https://github.com/iZettle/api-blueprint/blob/master/lib/api-blueprint/builder.rb) to see what those methods do.
 
@@ -171,15 +171,15 @@ If an API response includes an `errors` object, ApiBlueprint uses it to assign `
 
 Certain response statuses will also cause ApiBlueprint to behave in different ways:
 
-| HTTP Status range | Behavior |
-| ----------------- | -------- |
-| 200 - 400 | Objects are built normally, no errors raised |
-| 401 | raises `ApiBlueprint::UnauthenticatedError` |
-| 404 | raises `ApiBlueprint::NotFoundError` |
-| 402 - 499 | raises `ApiBlueprint::ClientError` |
-| 500 - 599 | raises `ApiBlueprint::ServerError` |
+| HTTP Status range | Behavior                                     |
+| ----------------- | -------------------------------------------- |
+| 200 - 400         | Objects are built normally, no errors raised |
+| 401               | raises `ApiBlueprint::UnauthenticatedError`  |
+| 404               | raises `ApiBlueprint::NotFoundError`         |
+| 402 - 499         | raises `ApiBlueprint::ClientError`           |
+| 500 - 599         | raises `ApiBlueprint::ServerError`           |
 
-Additionally, if the request timesout or some other error occurs which prevents the request from ever receiving a response, an `ApiBlueprint::ConnectionFailed` error will be raised.
+Additionally, if the request has an error which prevents the request from ever receiving a response, an `ApiBlueprint::ConnectionFailed` error will be raised. If a request times out, an `ApiBlueprint::TimeoutError` error will be raised.
 
 ## Access to response headers and status codes
 

--- a/lib/api-blueprint.rb
+++ b/lib/api-blueprint.rb
@@ -39,6 +39,7 @@ module ApiBlueprint
   class DefinitionError < StandardError; end
   class BuilderError < StandardError; end
   class ConnectionFailed < StandardError; end
+  class TimeoutError < StandardError; end
   class ServerError < ResponseError; end
   class UnauthenticatedError < ResponseError; end
   class ClientError < ResponseError; end

--- a/lib/api-blueprint/blueprint.rb
+++ b/lib/api-blueprint/blueprint.rb
@@ -40,6 +40,8 @@ module ApiBlueprint
       after_build.present? ? after_build.call(runner, created) : created
     rescue Faraday::ConnectionFailed
       raise ApiBlueprint::ConnectionFailed
+    rescue Faraday::TimeoutError
+      raise ApiBlueprint::TimeoutError
     end
 
     def connection

--- a/spec/api-blueprint/blueprint_spec.rb
+++ b/spec/api-blueprint/blueprint_spec.rb
@@ -433,6 +433,14 @@ describe ApiBlueprint::Blueprint, "running" do
         ApiBlueprint::Blueprint.new(url: "http://timeout").run
       }.to raise_error(ApiBlueprint::ConnectionFailed)
     end
+
+    it "converts Faraday::TimeoutError to ApiBlueprint::TimeoutError" do
+        stub_request(:get, "http://timeout").to_raise(Faraday::TimeoutError.new)
+
+        expect {
+            ApiBlueprint::Blueprint.new(url: "http://timeout").run
+        }.to raise_error(ApiBlueprint::TimeoutError)
+    end
   end
 end
 


### PR DESCRIPTION
The advance service got congested the other day, causing many requests to take >10s, which caused them to time out (and raise an uncaught `Faraday::TimeoutError`). This simply adds a new `ApiBlueprint` error class that can be used instead of `Faraday::TimeoutError`.